### PR TITLE
Add `publish = false` to all crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "novusk"
 version = "4.0.0"
 authors = ["Nathan McMillan <nathanmcmillan54@gmail.com>"]
 edition = "2018"
+publish = false
 
 [workspace]
 members = [

--- a/arch/aarch64/Cargo.toml
+++ b/arch/aarch64/Cargo.toml
@@ -3,6 +3,7 @@ name = "aarch64"
 version = "0.1.0"
 edition = "2021"
 description = "Aarch64/arm64 kernel support"
+publish = false
 
 [lib]
 name = "aarch64_kernel_lib"

--- a/arch/arm/Cargo.toml
+++ b/arch/arm/Cargo.toml
@@ -3,6 +3,7 @@ name = "arm"
 version = "0.1.0"
 edition = "2021"
 description = "ARM (32) kernel"
+publish = false
 
 [dependencies]
 asminc = { path = "../../include/asm/" }

--- a/arch/riscv/Cargo.toml
+++ b/arch/riscv/Cargo.toml
@@ -3,6 +3,7 @@ name = "riscv"
 version = "0.1.0"
 edition = "2021"
 description = "Support for RISCV32/64"
+publish = false
 
 [dependencies]
 hifive1 = { version = "0.10.0" }

--- a/arch/x86_64/Cargo.toml
+++ b/arch/x86_64/Cargo.toml
@@ -3,6 +3,7 @@ name = "x86_64"
 version = "0.1.0"
 edition = "2021"
 description = "x86_64 support for Novusk"
+publish = false
 
 [lib]
 name = "x86_64_kernel_lib"

--- a/arch/xtensa/Cargo.toml
+++ b/arch/xtensa/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtensa"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 device = { path = "../../drivers/device/" }

--- a/drivers/boot/nkuefi/Cargo.toml
+++ b/drivers/boot/nkuefi/Cargo.toml
@@ -3,6 +3,7 @@ name = "nkuefi"
 version = "0.1.0"
 edition = "2021"
 description = "A small bootloader for Novusk"
+publish = false
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = "0.14.7"

--- a/drivers/cpu/Cargo.toml
+++ b/drivers/cpu/Cargo.toml
@@ -3,5 +3,6 @@ name = "cpu"
 version = "0.1.0"
 edition = "2021"
 description = "CPU info"
+publish = false
 
 [dependencies]

--- a/drivers/device/Cargo.toml
+++ b/drivers/device/Cargo.toml
@@ -3,5 +3,6 @@ name = "device"
 version = "0.1.0"
 edition = "2021"
 description = "Traits for device specific drivers"
+publish = false
 
 [dependencies]

--- a/drivers/display/ssd/Cargo.toml
+++ b/drivers/display/ssd/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ssd"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 display-interface-i2c = "0.4.0"

--- a/drivers/fb/Cargo.toml
+++ b/drivers/fb/Cargo.toml
@@ -3,6 +3,7 @@ name = "fb"
 version = "0.1.0"
 edition = "2021"
 description = "A frame buffer driver"
+publish = false
 
 [dependencies]
 font8x8 = { version = "0.3.1", default-features = false }

--- a/drivers/firmware/esp/Cargo.toml
+++ b/drivers/firmware/esp/Cargo.toml
@@ -3,6 +3,7 @@ name = "esp"
 version = "0.1.0"
 edition = "2021"
 description = "Support for Xtensa Esp boards and RISCV in the fututre"
+publish = false
 
 [dependencies]
 esp32-hal = "0.3.0"

--- a/drivers/firmware/sifive/Cargo.toml
+++ b/drivers/firmware/sifive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sifive"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 device = { path = "../../device/" }

--- a/drivers/firmware/soc/Cargo.toml
+++ b/drivers/firmware/soc/Cargo.toml
@@ -3,5 +3,6 @@ name = "soc"
 version = "0.1.0"
 edition = "2021"
 description = "Used for writing SOC drivers"
+publish = false
 
 [dependencies]

--- a/drivers/firmware/soc/bcm/Cargo.toml
+++ b/drivers/firmware/soc/bcm/Cargo.toml
@@ -3,6 +3,7 @@ name = "bcm"
 version = "0.1.0"
 edition = "2021"
 description = "An SOC driver for Broadcom CPUs"
+publish = false
 
 [dependencies]
 asminc = { path = "../../../../include/asm/" }

--- a/drivers/firmware/sunfounder/sf_rpilcd_35/Cargo.toml
+++ b/drivers/firmware/sunfounder/sf_rpilcd_35/Cargo.toml
@@ -3,6 +3,7 @@ name = "sf_rpilcd_35"
 version = "0.1.0"
 edition = "2021"
 description = "Support for the SunFounder RaspberryPi 3.5in display"
+publish = false
 
 [dependencies]
 novuskinc = { path = "../../../../include/novusk/" }

--- a/drivers/fom_os/Cargo.toml
+++ b/drivers/fom_os/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Nathan McMillan <nathanmcmillan54@gmail.com>"]
 edition = "2021"
 description = "Setup for all versions of the FOMOS operating system"
+publish = false
 
 [dependencies]
 novuskinc = "0.1.1"

--- a/drivers/gpu/Cargo.toml
+++ b/drivers/gpu/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gpu"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 novuskinc = { path = "../../include/novusk/" }

--- a/drivers/gpu/armfb/Cargo.toml
+++ b/drivers/gpu/armfb/Cargo.toml
@@ -3,6 +3,7 @@ name = "armfb"
 version = "0.1.0"
 edition = "2021"
 description = "ARM 32/64 bit frambuffer graphics"
+publish = false
 
 [lib]
 crate-type = ["staticlib"]

--- a/drivers/gpu/vgag/Cargo.toml
+++ b/drivers/gpu/vgag/Cargo.toml
@@ -3,6 +3,7 @@ name = "vgag"
 version = "0.1.0"
 edition = "2021"
 description = "Vga graphics driver"
+publish = false
 
 [dependencies]
 asminc = { path = "../../../include/asm/" }

--- a/drivers/input/keyboard/Cargo.toml
+++ b/drivers/input/keyboard/Cargo.toml
@@ -3,6 +3,7 @@ name = "keyboard"
 version = "0.1.0"
 edition = "2021"
 description = "Keyboard input handler"
+publish = false
 
 [dependencies]
 pc-keyboard = "0.5.1"

--- a/drivers/input/keyboard/pc_keyboard/Cargo.toml
+++ b/drivers/input/keyboard/pc_keyboard/Cargo.toml
@@ -3,6 +3,7 @@ name = "pc_keyboard"
 version = "0.1.0"
 edition = "2021"
 description = "A driver for to handle PC Keyboard input"
+publish = false
 
 [dependencies]
 asminc = { path = "../../../../include/asm/" }

--- a/drivers/input/mouse/Cargo.toml
+++ b/drivers/input/mouse/Cargo.toml
@@ -3,5 +3,6 @@ name = "mouse"
 version = "0.1.0"
 edition = "2021"
 description = "Mouse traits and handler"
+publish = false
 
 [dependencies]

--- a/drivers/input/mouse/kb_mouse/Cargo.toml
+++ b/drivers/input/mouse/kb_mouse/Cargo.toml
@@ -3,6 +3,7 @@ name = "kb_mouse"
 version = "0.1.0"
 edition = "2021"
 description = "Kb Mouse (keyboard mouse), if mouse drivers aren't working you can use the arrow keys."
+publish = false
 
 [dependencies]
 novuskinc = { path = "../../../../include/novusk/" }

--- a/drivers/input/mouse/ps2_mouse/Cargo.toml
+++ b/drivers/input/mouse/ps2_mouse/Cargo.toml
@@ -3,6 +3,7 @@ name = "ps2_mouse"
 version = "0.1.0"
 edition = "2021"
 description = "PS2 mouse support"
+publish = false
 
 [dependencies]
 kinfo = { path = "../../../../kernel/kinfo/" }

--- a/drivers/irqchip/i8259/Cargo.toml
+++ b/drivers/irqchip/i8259/Cargo.toml
@@ -3,6 +3,7 @@ name = "i8259"
 version = "0.1.0"
 edition = "2021"
 description = "A driver for the PIC8259 IRQ chip"
+publish = false
 
 [dependencies]
 asminc = { path = "../../../include/asm/" }

--- a/drivers/irqchip/ibcm/Cargo.toml
+++ b/drivers/irqchip/ibcm/Cargo.toml
@@ -3,6 +3,7 @@ name = "ibcm"
 version = "0.1.0"
 edition = "2021"
 description = "BCM irqchip driver"
+publish = false
 
 [lib]
 crate-type = ["staticlib"]

--- a/drivers/irqchip/invic/Cargo.toml
+++ b/drivers/irqchip/invic/Cargo.toml
@@ -3,6 +3,7 @@ name = "invic"
 version = "0.1.0"
 edition = "2021"
 description = "NVIC irqchip driver"
+publish = false
 
 [dependencies]
 cortex-m = "0.7.5"

--- a/drivers/net/ethernet/Cargo.toml
+++ b/drivers/net/ethernet/Cargo.toml
@@ -3,6 +3,7 @@ name = "ethernet"
 version = "0.1.0"
 edition = "2021"
 description = "For writing ethernet drivers"
+publish = false
 
 [dependencies]
 novuskinc = { path = "../../../include/novusk/" }

--- a/drivers/platform/arm/hio/Cargo.toml
+++ b/drivers/platform/arm/hio/Cargo.toml
@@ -3,6 +3,7 @@ name = "hio"
 version = "0.1.0"
 edition = "2021"
 description = "Semihosting I/O for ARM"
+publish = false
 
 [dependencies]
 novuskinc = { path = "../../../../include/novusk/" }

--- a/drivers/platform/rpi/Cargo.toml
+++ b/drivers/platform/rpi/Cargo.toml
@@ -3,6 +3,7 @@ name = "rpi"
 version = "0.1.0"
 edition = "2021"
 description = "Setup for RaspberryPi devices"
+publish = false
 
 [lib]
 path = "src/lib.rs"

--- a/drivers/platform/stellaris/Cargo.toml
+++ b/drivers/platform/stellaris/Cargo.toml
@@ -3,6 +3,7 @@ name = "stellaris"
 version = "0.1.0"
 edition = "2021"
 description = "A driver for Stellaris devices"
+publish = false
 
 [dependencies]
 asminc = { path = "../../../include/asm/" }

--- a/drivers/platform/stellaris/stellariskern/Cargo.toml
+++ b/drivers/platform/stellaris/stellariskern/Cargo.toml
@@ -3,6 +3,7 @@ name = "stellariskern"
 version = "0.1.0"
 edition = "2021"
 description = "Stellaris device specific kernel"
+publish = false
 
 [[bin]]
 name = "a32dImage"

--- a/drivers/platform/stm/Cargo.toml
+++ b/drivers/platform/stm/Cargo.toml
@@ -3,6 +3,7 @@ name = "stm"
 version = "0.1.0"
 edition = "2021"
 description = "Support for ST devices, mainly STM32 boards"
+publish = false
 
 [dependencies]
 asminc = { path = "../../../include/asm/" }

--- a/drivers/platform/stm/stmkern/Cargo.toml
+++ b/drivers/platform/stm/stmkern/Cargo.toml
@@ -3,6 +3,7 @@ name = "stmkern"
 version = "0.1.0"
 edition = "2021"
 description = "STM device specific kernel"
+publish = false
 
 [dependencies]
 arm = { path = "../../../../arch/arm/" }

--- a/drivers/storage/lba/Cargo.toml
+++ b/drivers/storage/lba/Cargo.toml
@@ -3,6 +3,7 @@ name = "lba"
 version = "0.1.0"
 edition = "2021"
 description = "Logical Block Addressing (LBA) driver for x86_64"
+publish = false
 
 [dependencies]
 asminc = { path = "../../../include/asm/" }

--- a/drivers/usbd/Cargo.toml
+++ b/drivers/usbd/Cargo.toml
@@ -3,5 +3,6 @@ name = "usbd"
 version = "0.1.0"
 edition = "2021"
 description = "USB Driver"
+publish = false
 
 [dependencies]

--- a/fs/tempfs/Cargo.toml
+++ b/fs/tempfs/Cargo.toml
@@ -3,6 +3,7 @@ name = "tempfs"
 version = "0.1.0"
 edition = "2021"
 description = "Temporary File System"
+publish = false
 
 [dependencies]
 vfs = { path = "../vfs/" }

--- a/fs/vfs/Cargo.toml
+++ b/fs/vfs/Cargo.toml
@@ -3,6 +3,7 @@ name = "vfs"
 version = "0.1.0"
 edition = "2021"
 description = "A Virtual File System, for making support for other file systems"
+publish = false
 
 [dependencies]
 #mio = { path = "../../mm/mio/" }

--- a/include/asm/Cargo.toml
+++ b/include/asm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "asminc"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86_64 = "0.14.9"

--- a/include/ctypes/Cargo.toml
+++ b/include/ctypes/Cargo.toml
@@ -3,5 +3,6 @@ name = "ctypes"
 version = "0.1.0"
 edition = "2021"
 description = "C types for Rust"
+publish = false
 
 [dependencies]

--- a/include/novusk/Cargo.toml
+++ b/include/novusk/Cargo.toml
@@ -3,6 +3,7 @@ name = "novuskinc"
 version = "0.1.0"
 edition = "2021"
 description = "A lib used for anything related to Novusk"
+publish = false
 
 [dependencies]
 

--- a/init/Cargo.toml
+++ b/init/Cargo.toml
@@ -3,6 +3,7 @@ name = "init"
 version = "0.1.0"
 edition = "2021"
 description = "Main kernel initialization"
+publish = false
 
 [lib]
 name = "init"

--- a/kernel/irq/Cargo.toml
+++ b/kernel/irq/Cargo.toml
@@ -3,6 +3,7 @@ name = "irq"
 version = "0.1.0"
 edition = "2021"
 description = "Main kernel IRQ handler"
+publish = false
 
 # [lib]
 # name = "irq"

--- a/kernel/kinfo/Cargo.toml
+++ b/kernel/kinfo/Cargo.toml
@@ -3,6 +3,7 @@ name = "kinfo"
 version = "0.1.0"
 edition = "2021"
 description = "Printing kernel info (ok/not ok)"
+publish = false
 
 [dependencies]
 printk = { path = "../printk/" }

--- a/kernel/konfig/Cargo.toml
+++ b/kernel/konfig/Cargo.toml
@@ -3,6 +3,7 @@ name = "konfig"
 version = "0.1.0"
 edition = "2021"
 description = "Kernel configurations"
+publish = false
 
 [dependencies]
 lazy_static = { version = "1.4", features = ["spin_no_std"] }

--- a/kernel/modules/Cargo.toml
+++ b/kernel/modules/Cargo.toml
@@ -3,6 +3,7 @@ name = "modules"
 version = "0.1.0"
 edition = "2021"
 description = "Starts and handles kernel modules"
+publish = false
 
 [dependencies]
 novuskinc = { path = "../../include/novusk/" }

--- a/kernel/modules/ex1/Cargo.toml
+++ b/kernel/modules/ex1/Cargo.toml
@@ -3,6 +3,7 @@ name = "ex1"
 version = "0.1.0"
 authors = ["Nathan McMillan <nathanmcmillan54@gmail.com>"]
 edition = "2021"
+publish = false
 
 [dependencies]
 novuskinc = { path = "../../../include/novusk/" }

--- a/kernel/modules/fscheck/Cargo.toml
+++ b/kernel/modules/fscheck/Cargo.toml
@@ -3,7 +3,7 @@ name = "fscheck"
 version = "0.1.0"
 authors = ["Nathan McMillan <nathanmcmillan54@gmail.com>"]
 edition = "2021"
-
+publish = false
 
 [dependencies]
 # fat = { path = "../../../fs/fat/" }

--- a/kernel/notify/Cargo.toml
+++ b/kernel/notify/Cargo.toml
@@ -3,6 +3,7 @@ name = "notify"
 version = "0.1.0"
 edition = "2021"
 description = "Handles events"
+publish = false
 
 [dependencies]
 keyboard = { path = "../../drivers/input/keyboard/" }

--- a/kernel/power/Cargo.toml
+++ b/kernel/power/Cargo.toml
@@ -3,6 +3,7 @@ name = "power"
 version = "0.1.0"
 edition = "2021"
 description = "Power managment for Novusk"
+publish = false
 
 [dependencies]
 novuskinc = { path = "../../include/novusk/" }

--- a/kernel/printk/Cargo.toml
+++ b/kernel/printk/Cargo.toml
@@ -3,6 +3,7 @@ name = "printk"
 version = "0.1.0"
 edition = "2021"
 description = "Kernel printing function and macro"
+publish = false
 
 [lib]
 name = "printk"

--- a/kernel/setup/Cargo.toml
+++ b/kernel/setup/Cargo.toml
@@ -3,6 +3,7 @@ name = "setup"
 version = "0.1.0"
 edition = "2021"
 description = "Setup before kernel_init and setup before kernel_main"
+publish = false
 
 [dependencies]
 novuskinc = { path = "../../include/novusk/" }

--- a/kernel/time/Cargo.toml
+++ b/kernel/time/Cargo.toml
@@ -3,5 +3,6 @@ name = "time"
 version = "0.1.0"
 edition = "2021"
 description = "Kernel and real time (when supported)"
+publish = false
 
 [dependencies]

--- a/lib/libbmu/Cargo.toml
+++ b/lib/libbmu/Cargo.toml
@@ -3,6 +3,7 @@ name = "libbmu"
 version = "0.1.0"
 edition = "2021"
 description = "Bare Metal Userspace Library, a library for Novusk's 'userspace' on embbeded devices"
+publish = false
 
 [dependencies]
 memory = { path = "../../mm/memory/" }

--- a/lib/libc/unistd/Cargo.toml
+++ b/lib/libc/unistd/Cargo.toml
@@ -3,6 +3,7 @@ name = "unistd"
 version = "0.1.0"
 edition = "2021"
 description = "unistd.h"
+publish = false
 
 [dependencies]
 cfg-if = "1.0.0"

--- a/lib/libcolor/Cargo.toml
+++ b/lib/libcolor/Cargo.toml
@@ -3,5 +3,6 @@ name = "libcolor"
 version = "0.1.0"
 edition = "2021"
 description = "Colors in enums"
+publish = false
 
 [dependencies]

--- a/lib/libost/Cargo.toml
+++ b/lib/libost/Cargo.toml
@@ -3,6 +3,7 @@ name = "libost"
 version = "0.1.0"
 edition = "2021"
 description = "OS tools"
+publish = false
 
 [dependencies]
 # gpu = { path = "../../drivers/gpu/" }

--- a/lib/libwin/Cargo.toml
+++ b/lib/libwin/Cargo.toml
@@ -3,6 +3,7 @@ name = "libwin"
 version = "0.1.0"
 edition = "2021"
 description = "Library for GUI windows"
+publish = false
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 novuskinc = { path = "../../include/novusk/" }

--- a/mm/memory/Cargo.toml
+++ b/mm/memory/Cargo.toml
@@ -3,6 +3,7 @@ name = "memory"
 version = "0.1.0"
 edition = "2021"
 description = "memory.h"
+publish = false
 
 [dependencies]
 ctypes = { path = "../../include/ctypes/" }

--- a/mm/mio/Cargo.toml
+++ b/mm/mio/Cargo.toml
@@ -3,5 +3,6 @@ name = "mio"
 version = "0.1.0"
 edition = "2021"
 description = "Mermory Input Output"
+publish = false
 
 [dependencies]

--- a/mm/nmallocator/Cargo.toml
+++ b/mm/nmallocator/Cargo.toml
@@ -3,6 +3,7 @@ name = "nmallocator"
 version = "0.1.0"
 edition = "2021"
 description = "Novusk Memory Allocator"
+publish = false
 
 [dependencies]
 wee_alloc = { version = "0.4.5", features = ["static_array_backend"] }

--- a/net/ethernet/stm_eth/Cargo.toml
+++ b/net/ethernet/stm_eth/Cargo.toml
@@ -3,6 +3,7 @@ name = "stm_eth"
 version = "0.1.0"
 edition = "2021"
 description = "Ethernet driver for STM32 devices"
+publish = false
 
 [dependencies]
 ethernet = { path = "../../../drivers/net/ethernet/" }

--- a/sound/x86_64-sound/Cargo.toml
+++ b/sound/x86_64-sound/Cargo.toml
@@ -3,6 +3,7 @@ name = "x86_64-sound"
 version = "0.1.0"
 edition = "2021"
 description = "Sound 'driver' for x86_64"
+publish = false
 
 [dependencies]
 pc-beeper = { git = "https://github.com/NathanMcMillan54/pc-beeper" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tests"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 libc = "0.2.126"

--- a/tools/bootloader_image/Cargo.toml
+++ b/tools/bootloader_image/Cargo.toml
@@ -3,6 +3,7 @@ name = "bootloader_image"
 version = "0.1.0"
 edition = "2021"
 description = "Links x86_64 Novusk with bootloader v0.10+"
+publish = false
 
 [dependencies]
 bootloader-locator = "0.0.4"

--- a/tools/build/buildkern/Cargo.toml
+++ b/tools/build/buildkern/Cargo.toml
@@ -3,5 +3,6 @@ name = "buildkern"
 version = "0.1.0"
 edition = "2021"
 description = "Reads configuration file to see what needs to be compiled  to build the kernel."
+publish = false
 
 [dependencies]

--- a/tools/build/ccbuild/Cargo.toml
+++ b/tools/build/ccbuild/Cargo.toml
@@ -3,5 +3,6 @@ name = "ccbuild"
 version = "0.1.0"
 edition = "2021"
 description = "A library for compiling C and Assembly files in Rust build scripts"
+publish = false
 
 [dependencies]


### PR DESCRIPTION
This would be required for adding cargo-deny security checks to CI on Quantii.  I'll do another PR for v3.